### PR TITLE
feat: add kaap project definitions

### DIFF
--- a/.github/workflows/kaap-entity-validation.yaml
+++ b/.github/workflows/kaap-entity-validation.yaml
@@ -1,0 +1,28 @@
+# Copyright (C) 2023 TomTom NV. All rights reserved.
+
+name: KaaP Entity Validation
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "kaap/**.yaml"
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency: -
+
+jobs:
+  validate-kaap-entities:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate KaaP entities
+        uses: tomtom-internal/kaap-project-definition-validator@v1.0.0
+        with:
+          projectPath: ./kaap/**/*.yaml

--- a/kaap/example-composite-action.yaml
+++ b/kaap/example-composite-action.yaml
@@ -1,0 +1,20 @@
+# Copyright (C) 2023 TomTom NV. All rights reserved.
+
+apiVersion: tomtom.com/v1alpha1
+kind: KaaPProject
+metadata:
+  name: example-composite-action
+  title: example-composite-action
+  description: The definition of your KaaP Project example-composite-action.
+  annotations:
+    tomtom.com/kaap-project-repository: armandocollazo-tomtom/example-composite-action
+  tags:
+    - project
+    - kaap
+spec:
+  securityGroupId: 17238b9e-fa40-4172-a895-196c6b1f80ba
+  slackChannel: test
+  type: azure
+  owner: group:default/my-team-dev
+  system: kaap-project
+  lifecycle: production

--- a/kaap/kaap-location.yaml
+++ b/kaap/kaap-location.yaml
@@ -1,0 +1,10 @@
+# Copyright (C) 2023 TomTom NV. All rights reserved.
+
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: kaap-catalog-location
+  description: a reference to all kaap entities in the current repository
+spec:
+  targets:
+    - ./kaap/*.yaml


### PR DESCRIPTION
## Goal of the PR
This PR add the definition files for the KaaP project example-composite-action. The defintion files are the single source of true of your KaaP project. 
The files are used to create the KaaP project via [Frontstage](https://frontstage.tomtomgroup.com/).
## Changes
  - Add the `kaap-project.yaml` for the KaaP project example-composite-action.
  - Add the `kaap-location.yaml` for the KaaP project to be visible in Frontstage.
  - Add the `kaap-entity-validation.yaml` github workflow to validate the kaap definition in your repository.
